### PR TITLE
Fix link to security settings

### DIFF
--- a/docs/4_usage/1_projects.md
+++ b/docs/4_usage/1_projects.md
@@ -34,7 +34,7 @@ Save your selection and continue with the wizard.
 
 Next, you can choose which security features you want to enable. If you want to tune the features, you can do that after the wizard in the security settings of your project.
 
-You can find all information about the security features [here](./settings#security-settings).
+You can find all information about the security features [here](../settings#security-settings).
 
 You do not have to enable any features in the wizard. You can enable or disable these features anytime in the security settings.
 


### PR DESCRIPTION
This links ends up on https://documentation.mosparo.io/docs/usage/projects/settings#security-settings, while the actual URL is https://documentation.mosparo.io/docs/usage/settings/#security-settings